### PR TITLE
Updated reference parent recipe

### DIFF
--- a/Google/keychainminder.munki.recipe
+++ b/Google/keychainminder.munki.recipe
@@ -39,7 +39,7 @@
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.clburlison.download.macops-keychainminder</string>
+	<string>com.github.clburlison.download.keychainminder</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Got an error from `autopkg info keychainminder.munki` that `Didn't find a recipe for com.github.clburlison.download.macops-keychainminder.`
That reference parent recipe doesn't exist.  I assume it's supposed to be your download recipe of `com.github.clburlison.download.keychainminder`
