### PR TITLE
Arq change

### DIFF
--- a/HaystackSoftware/Arq.download.recipe
+++ b/HaystackSoftware/Arq.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://www.arqbackup.com/download/Arq_OSX.zip</string>
+				<string>https://www.arqbackup.com/download/Arq.dmg</string>
 			</dict>
 		</dict>
 		<dict>
@@ -31,21 +31,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
+				<key>strict_verification</key>
 				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%pathname%/%NAME%.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.haystacksoftware.Arq" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "48ZCSDVL96")</string>
 			</dict>
@@ -56,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/HaystackSoftware/Arq.install.recipe
+++ b/HaystackSoftware/Arq.install.recipe
@@ -21,18 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>items_to_copy</key>
 				<array>
 					<dict>

--- a/HaystackSoftware/Arq.munki.recipe
+++ b/HaystackSoftware/Arq.munki.recipe
@@ -36,33 +36,13 @@
   	<array>
       <dict>
           <key>Processor</key>
-          <string>Unarchiver</string>
-          <key>Arguments</key>
-          <dict>
-              <key>archive_path</key>
-              <string>%pathname%</string>
-          </dict>
-      </dict>
-      <dict>
-          <key>Processor</key>
-          <string>DmgCreator</string>
-          <key>Arguments</key>
-          <dict>
-              <key>dmg_root</key>
-              <string>%RECIPE_CACHE_DIR%/Arq/Applications</string>
-              <key>dmg_path</key>
-              <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-          </dict>
-      </dict>
-      <dict>
-          <key>Processor</key>
           <string>MunkiImporter</string>
           <key>Arguments</key>
           <dict>
               <key>repo_subdirectory</key>
               <string>%MUNKI_REPO_SUBDIR%</string>
               <key>pkg_path</key>
-              <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+              <string>%pathname%</string>
               <key>additional_pkginfo</key>
               <dict>
                   <key>display_name</key>

--- a/HaystackSoftware/Arq.munki.recipe
+++ b/HaystackSoftware/Arq.munki.recipe
@@ -22,6 +22,8 @@
             <string>Arq automatically backs up all your Macs. Your files are stored securely, readable only by you. Backups can be stored on Amazon S3, Amazon Glacier, Dropbox, Google Drive, Google Cloud Storage, Microsoft OneDrive, SFTP, and DreamObjects.</string>
             <key>display_name</key>
             <string>Arq</string>
+            <key>minimum_os_version</key>
+            <string>10.7.0</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>

--- a/HaystackSoftware/Arq.pkg.recipe
+++ b/HaystackSoftware/Arq.pkg.recipe
@@ -22,35 +22,8 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
 			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Arq has a .dmg as their advertised download from the downloads page at https://www.arqbackup.com/download/. A quick MD5 check of the app binary in the .zip and the .dmg are identical.

- Changed the workflows to use the .dmg to eliminate steps in dealing with the .zip.

- Added `strict_verification` for CodeSignatureVerifier since it is evaluating a .app. This is supported in autopkg 1.0.3+.  Earlier versions will just ignore the key.

-Eric