### PR TITLE
Updated download URL

### DIFF
--- a/HaystackSoftware/Arq.download.recipe
+++ b/HaystackSoftware/Arq.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://www.arqbackup.com/download/Arq.dmg</string>
+				<string>https://www.arqbackup.com/download/arqbackup/Arq.dmg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
The download URL changed and was causing a 404 on the existing recipe.
I presume the change happened when they introduced the new consumer based Cloud backup product.

-Eric