### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Anton Keks/AngryIPScanner.install.recipe
+++ b/Anton Keks/AngryIPScanner.install.recipe
@@ -54,7 +54,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Angry IP Scanner.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Anton Keks/AngryIPScanner.pkg.recipe
+++ b/Anton Keks/AngryIPScanner.pkg.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Angry IP Scanner.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/HaystackSoftware/Arq.download.recipe
+++ b/HaystackSoftware/Arq.download.recipe
@@ -34,7 +34,7 @@
 				<key>strict_verification</key>
 				<true/>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Arq.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.haystacksoftware.Arq" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "48ZCSDVL96")</string>
 			</dict>
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Arq.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/HaystackSoftware/Arq.install.recipe
+++ b/HaystackSoftware/Arq.install.recipe
@@ -28,7 +28,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Arq.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Squirrels LLC/Reflector3.download.recipe
+++ b/Squirrels LLC/Reflector3.download.recipe
@@ -43,7 +43,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Reflector 3.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.squirrels.Reflector-3" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "67X2M9MT5G")</string>
 			</dict>

--- a/Squirrels LLC/Reflector3.install.recipe
+++ b/Squirrels LLC/Reflector3.install.recipe
@@ -28,7 +28,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Reflector 3.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Squirrels LLC/Reflector3.pkg.recipe
+++ b/Squirrels LLC/Reflector3.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Reflector 3.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Reflector 3.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.