### PR TITLE
Update Arq.download.recipe

### DIFF
--- a/HaystackSoftware/Arq.download.recipe
+++ b/HaystackSoftware/Arq.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://www.arqbackup.com/download/arqbackup/Arq.dmg</string>
+				<string>https://www.arqbackup.com/download/arqbackup/Arq.zip</string>
 			</dict>
 		</dict>
 		<dict>
@@ -29,12 +29,22 @@
 			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>strict_verification</key>
 				<true/>
 				<key>input_path</key>
-				<string>%pathname%/Arq.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Arq.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.haystacksoftware.Arq" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "48ZCSDVL96")</string>
 			</dict>
@@ -45,7 +55,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/Arq.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Arq.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>


### PR DESCRIPTION
Update URL and add unarchiver to the download process now that arq is being distributed in a zip instead of a dmg