### PR TITLE
Adjust MunkiPkginfoMerger arguments

### DIFF
--- a/HaystackSoftware/Arq.munki.recipe
+++ b/HaystackSoftware/Arq.munki.recipe
@@ -50,11 +50,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>display_name</key>
-					<string>%NAME%</string>
-				</dict>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>repo_subdirectory</key>


### PR DESCRIPTION
If `display_name` is omitted from the pkginfo, it defaults to `name`, so this `additional_pkginfo` dictionary is not necessary.