### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/HaystackSoftware/Arq.pkg.recipe
+++ b/HaystackSoftware/Arq.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.clburlison.pkg.Arq</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.haystacksoftware.Arq</string>
 		<key>NAME</key>
 		<string>Arq</string>
 	</dict>
@@ -22,13 +20,13 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>AppPkgCreator</string>
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Arq.app</string>
 			</dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ HaystackSoftware/Arq.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/clburlison-recipes/HaystackSoftware/Arq.pkg.recipe
Processing repos/clburlison-recipes/HaystackSoftware/Arq.pkg.recipe...
URLDownloader
{'Input': {'url': 'https://www.arqbackup.com/download/arqbackup/Arq.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/downloads/Arq.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/downloads/Arq.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Arq.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/downloads/Arq.zip to ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq/Arq.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.haystacksoftware.Arq" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "48ZCSDVL96")',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq/Arq.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq/Arq.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq/Arq.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq/Arq.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 5.19.2 in file ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq/Arq.app/Contents/Info.plist
{'Output': {'version': '5.19.2'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq/Arq.app',
           'version': '5.19.2'}}
AppPkgCreator: BundleID: com.haystacksoftware.Arq
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq/Arq.app to ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/payload/Applications/Arq.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.haystacksoftware.Arq',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq-5.19.2.pkg',
                                                        'version': '5.19.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '5.19.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/receipts/Arq.pkg-receipt-20210213-225416.plist

The following packages were built:
    Identifier                Version  Pkg Path                                                                           
    ----------                -------  --------                                                                           
    com.haystacksoftware.Arq  5.19.2   ~/Library/AutoPkg/Cache/com.github.clburlison.pkg.Arq/Arq-5.19.2.pkg  
```

