### PR TITLE
Fix Sparkle feed versioning

### DIFF
--- a/Squirrels LLC/Reflector3.download.recipe
+++ b/Squirrels LLC/Reflector3.download.recipe
@@ -14,7 +14,7 @@
 		<string>https://updates.airsquirrels.com/Reflector3/Mac/Reflector3.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -29,8 +29,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
+				<key>url</key>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Squirrels LLC/Reflector3.pkg.recipe
+++ b/Squirrels LLC/Reflector3.pkg.recipe
@@ -14,7 +14,7 @@
 		<string>Reflector 3</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.0.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.clburlison.download.Reflector3</string>
 	<key>Process</key>
@@ -22,58 +22,15 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-				</dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>input_plist_path</key>
+				<string>%pathname%/Reflector 3.app/Contents/Info.plist</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgRootCreator</string>
+			<string>Versioner</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%pkgroot%/Applications/Reflector 3.app</string>
-				<key>source_path</key>
-				<string>%pathname%/Reflector 3.app</string>
-			</dict>
 			<key>Processor</key>
-			<string>Copier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Reflector started adding an update ad in their Sparkle feed (https://updates.airsquirrels.com/Reflector3/Mac/Reflector3.xml) ...

```<enclosure url="https://airsquirrels-downloads.s3.amazonaws.com/Reflector3/Mac/Reflector-3.2.1.dmg" sparkle:version="4000" sparkle:shortVersionString=" > Reflector 4 is a paid upgrade - Buy now at www.reflectorapp.com" length="43064302" type="application/octet-stream" sparkle:dsaSignature="MCwCFAEm2YRCbI3iZ+ByL6K+E4JcbBnrAhRx1lvX0rz1TVWb0sduOwa5DbezLQ=="/>```

The full `shortVersionString` ended up in the DMG and package name. Edited recipes to use the base download DMG name and reference Info.plist CFBundleShortVersionString for version. I also moved the package recipe to AppPkgCreator. The pkg recipe was failing entirely due to the string not being a valid version.