### PR TITLE
Deprecate Reflector 3 recipes

### DIFF
--- a/Squirrels LLC/Reflector3.download.recipe
+++ b/Squirrels LLC/Reflector3.download.recipe
@@ -14,9 +14,18 @@
 		<string>https://updates.airsquirrels.com/Reflector3/Mac/Reflector3.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Reflector 4 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Reflector 4 is the latest version. This PR deprecates the Reflector 3 recipes in this repo, and points users to an alternative Reflector 4 recipe in the dataJAR-recipes repo.