### PR TITLE
Deprecate Amazon Cloud Drive recipes

### DIFF
--- a/Amazon/AmazonCloudDrive.download.recipe
+++ b/Amazon/AmazonCloudDrive.download.recipe
@@ -18,9 +18,18 @@
 		<string>Amazon Drive</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Amazon announced that the Amazon Cloud Drive service would be discontinued on December 31, 2023. If you're looking for Amazon Photos, consider switching to the AmazonPhotos recipes in the joshua-d-miller-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Amazon has deprecated Amazon Cloud Drive as of December 2023. These recipes now download the Amazon Photos app, for which recipes have already been created at [joshua-d-miller-recipes](https://github.com/autopkg/joshua-d-miller-recipes/blob/master/Amazon/AmazonPhotos.download.recipe). Therefore the simplest action is to deprecate the non-working recipes in this repo.